### PR TITLE
Python version check fix

### DIFF
--- a/configure
+++ b/configure
@@ -6119,8 +6119,8 @@ $as_echo "yes" >&6; }
 		{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for a version of Python >= '3.6'" >&5
 $as_echo_n "checking for a version of Python >= '3.6'... " >&6; }
 		ac_supports_python_ver=`$PYTHON -c "import sys; \
-			ver = sys.version.split ()[0]; \
-			print (ver >= '3.6')"`
+			ver = sys.version_info[:2]; \
+			print(ver >= (3,6))"`
 		if test "$ac_supports_python_ver" = "True"; then
 		   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }


### PR DESCRIPTION
There is a problem with checking the python version in the configure file. Since versions have moved to double digits e.g 3.10 the version check will fail when the enviroment $PYTHON >= python 3.10. I.e. when running python 3.10 or greater:

> $PYTHON -c "import sys; ver = '3.10'; print(ver >= '3.6')" False

tested configure and make:

>./configure  --enable-2d-adaptivity --enable-sam && sudo make install   

works file