### PR TITLE
Ensure decreasing timestep when needed

### DIFF
--- a/ICFERST/src/Extract_From_State.F90
+++ b/ICFERST/src/Extract_From_State.F90
@@ -2555,7 +2555,7 @@ subroutine Adaptive_NonLinear(Mdims, packed_state, reference_field, its,&
                     if (PID_controller) then
                        auxR = PID_time_controller()
                        !Maybe the PID controller thinks is better to reduce more than just half, up to 0.25
-                       dt = max(max(0.5/decreaseFactor * dt, auxR*dt), min_ts)
+                       dt = max(min(0.5/decreaseFactor * dt, auxR*dt), min_ts)
                        !If PID_controller then update the status
                        auxR = PID_time_controller(reset=.true.)
                      else


### PR DESCRIPTION
Bugfix to ensure next timestep is smaller than previous when smaller timestep is needed. 